### PR TITLE
Add all animals from `mobs_animal`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -4,33 +4,66 @@
 
 local priv_name = "therianthrophy"
 
-local chicken_players = {}
+local transformed_players = {}
+local mob_data = {}
 
-minetest.register_on_leaveplayer(function(player)
-    chicken_players[player:get_player_name()] = nil
+core.register_on_leaveplayer(function(player)
+    transformed_players[player:get_player_name()] = nil
 end)
 
-player_api.register_model("mobs_chicken.b3d", {
-    animation_speed = 24,
-    textures = {"mobs_chicken.png"},
-    collisionbox = {-0.3, -0.75, -0.3, 0.3, 0.1, 0.3},
-    eye_height = 0,
-    animations = {
-        stand = {x = 1, y = 30},
-        lay = {x = 1, y = 30},
-        walk = {x = 71, y = 90},
-        mine = {x = 31, y = 70},
-        walk_mine = {x = 91, y = 110},
-        sit = {x = 1, y = 30}
-    }
-})
+local function register_animal_player_model(short_name, def)
+    local init_prop = def.initial_properties
+    local model = init_prop.mesh
+    local texture = def.texture_list[1][1]
+    local box = init_prop.collisionbox
+    -- Todo: find a better eye_height calculation
+    local eye_height = (box[5] - box[2]) / init_prop.visual_size.y + box[2]
+
+    local anim = def.animation
+    local anim_speed, stand_anim, walk_anim, mine_anim, walk_mine_anim
+    anim_speed = 15
+    if anim then
+        anim_speed = anim.speed_normal or anim_speed
+
+        stand_anim = {
+            x = anim.stand_start or 1,
+            y = anim.stand_end or 1
+        }
+        walk_anim = {
+            x = anim.walk_start or stand_anim.x,
+            y = anim.walk_end or stand_anim.y
+        }
+        mine_anim = {
+            x = anim.punch_start or walk_anim.x,
+            y = anim.punch_end or walk_anim.y
+        }
+        walk_mine_anim = {
+            x = anim.run_start or mine_anim.x,
+            y = anim.run_end or mine_anim.y
+        }
+    end
+
+    player_api.register_model(model, {
+        animation_speed = anim_speed,
+        textures = {texture},
+        collisionbox = box,
+        eye_height = eye_height,
+        animations = {
+            stand = stand_anim,
+            walk = walk_anim,
+            mine = mine_anim,
+            walk_mine = walk_mine_anim
+        }
+    })
+    mob_data[short_name] = {model, texture}
+end
 
 -- Override the skin update function to skip chicken players,
 -- so that the custom properties do not get changed
 local old_skin_apply = skins.skin_class.apply_skin_to_player
 skins.skin_class.apply_skin_to_player = function(self, player)
     local name = player:get_player_name()
-    if chicken_players[name] then
+    if transformed_players[name] then
         return
     end
     return old_skin_apply(self, player)
@@ -55,16 +88,16 @@ end
 
 local function to_human(player)
     local name = player:get_player_name()
-    chicken_players[name] = nil
+    transformed_players[name] = nil
     set_model(player, "skinsdb_3d_armor_character_5.b3d")
     skins.update_player_skin(player)
 end
 
-local function to_chicken(player)
+local function transform(player, model, texture)
     local name = player:get_player_name()
-    chicken_players[name] = true
-    set_model(player, "mobs_chicken.b3d")
-    player_api.set_textures(player, {"mobs_chicken.png"})
+    transformed_players[name] = true
+    set_model(player, model)
+    player_api.set_textures(player, {texture})
     -- Pop the player up a node so they dont fall into the node below
     player:set_pos(vector.add(player:get_pos(), vector.new(0, 1, 0)))
 end
@@ -74,39 +107,51 @@ minetest.register_privilege(priv_name, {
     give_to_singleplayer = false
 })
 
-
-minetest.register_chatcommand("human", {
-    params = "[<player>]",
-    description = "Turns player back into a human",
-    func = function(name, target)
-        if target ~= "" then
-            if not minetest.check_player_privs(name, {[priv_name] = true}) then
+core.register_chatcommand("transform", {
+    params = "[<player>] <animal>",
+    description = "Turns yourself or another player into an animal",
+    func = function(name, param)
+        local args = param:split(" ")
+        local target, animal = name, args[1]
+        if #args > 1 then
+            if not core.check_player_privs(name, {[priv_name] = true}) then
                 return false, "You don't have permission to transform other players."
             end
-            name = target
+            target, animal = args[1], args[2]
         end
-        local player = minetest.get_player_by_name(name)
+
+        local player = core.get_player_by_name(target)
         if not player then
-            return false, "Player does not exist."
+            return false, "Target is not logged in."
         end
-        to_human(player)
+
+        if animal == "human" then to_human(player) return end
+        local data = mob_data[animal]
+        if not data then
+            return false, "Animal does not exist."
+        end
+
+        transform(player, data[1], data[2])
     end
 })
 
-minetest.register_chatcommand("chicken", {
-    params = "[<player>]",
-    description = "Turns player into a chicken",
-    func = function(name, target)
-        if target ~= "" then
-            if not minetest.check_player_privs(name, {[priv_name] = true}) then
-                return false, "You don't have permission to transform other players."
-            end
-            name = target
+core.register_chatcommand("list_animals", {
+    description = "List the animals you can turn into with /transform",
+    func = function(name)
+        local animals = {}
+        for short_name, _ in pairs(mob_data) do
+            table.insert(animals, short_name)
         end
-        local player = minetest.get_player_by_name(name)
-        if not player then
-            return false, "Player does not exist."
-        end
-        to_chicken(player)
+        table.sort(animals)
+        return true, "Human, " .. table.concat(animals, ", ")
     end
 })
+
+core.register_on_joinplayer(function()
+    for name, _ in pairs(mobs.spawning_mobs) do
+        if name:sub(1, 12) == "mobs_animal:" then
+            local def = core.registered_entities[name]
+            register_animal_player_model(name:sub(13), def)
+        end
+    end
+end)


### PR DESCRIPTION
This PR replaces `/chicken` and `/human` with a `/transform` command that can be used with any mob from `mobs_animal`. `/transform human` turns you back into a human. Use `/transform <player> <animal>` to transform any other player into any other animal.

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/11c98cbb-198e-49f3-a7c3-042e9fffe4e8)
![image](https://github.com/user-attachments/assets/3d7c1954-12ee-4a8f-84f8-e104572495c5)
![image](https://github.com/user-attachments/assets/74ce3031-cc6b-494c-a6b2-84fc2c42268a)

</details>